### PR TITLE
Generate kubeconfigs from template instead of kubectl cmds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # A Terraform version of Kubernetes The Hard Way
 
+[![CircleCI](https://circleci.com/gh/marratj/kthw-terraform.svg?style=svg)](https://circleci.com/gh/marratj/kthw-terraform)
+
 This is my implementation of [Kubernetes The Hard Way](https://github.com/kelseyhightower/kubernetes-the-hard-way) in Terraform on Microsoft Azure instead of Google Cloud Platform.
 
 I'm doing this for 

--- a/kthw.tf
+++ b/kthw.tf
@@ -103,11 +103,11 @@ module "kubeconfig" {
   apiserver_public_ip = "${module.lb_masters.public_ip_address}"
   node_user           = "${var.node_user}"
 
-  kubelet_crt_files   = "${module.pki.kubelet_crt_files}"
-  kubelet_key_files   = "${module.pki.kubelet_key_files}"
-  kube-proxy_crt_file = "${module.pki.kube-proxy_crt_file}"
-  kube-proxy_key_file = "${module.pki.kube-proxy_key_file}"
-  ca_crt_file         = "${module.pki.kube_ca_crt_file}"
+  kubelet_crt_pems  = "${module.pki.kubelet_crt_pems}"
+  kubelet_key_pems  = "${module.pki.kubelet_key_pems}"
+  kube-proxy_crt_pem = "${module.pki.kube-proxy_crt_pem}"
+  kube-proxy_key_pem = "${module.pki.kube-proxy_key_pem}"
+  kube_ca_crt_pem    = "${module.pki.kube_ca_crt_pem}"
 }
 
 module "encryption_config" {

--- a/kthw.tf
+++ b/kthw.tf
@@ -100,6 +100,7 @@ module "kubeconfig" {
   source = "modules/kubeconfig"
 
   kubelet_node_names  = "${module.workers.names}"
+  kubelet_count       = "${var.worker_count}"
   apiserver_public_ip = "${module.lb_masters.public_ip_address}"
   node_user           = "${var.node_user}"
 

--- a/kthw.tf
+++ b/kthw.tf
@@ -103,8 +103,8 @@ module "kubeconfig" {
   apiserver_public_ip = "${module.lb_masters.public_ip_address}"
   node_user           = "${var.node_user}"
 
-  kubelet_crt_pems  = "${module.pki.kubelet_crt_pems}"
-  kubelet_key_pems  = "${module.pki.kubelet_key_pems}"
+  kubelet_crt_pems   = "${module.pki.kubelet_crt_pems}"
+  kubelet_key_pems   = "${module.pki.kubelet_key_pems}"
   kube-proxy_crt_pem = "${module.pki.kube-proxy_crt_pem}"
   kube-proxy_key_pem = "${module.pki.kube-proxy_key_pem}"
   kube_ca_crt_pem    = "${module.pki.kube_ca_crt_pem}"

--- a/modules/encryption_config/encryption_config.tpl
+++ b/modules/encryption_config/encryption_config.tpl
@@ -9,3 +9,4 @@ resources:
             - name: key1
               secret: ${encryption_key}
       - identity: {}
+

--- a/modules/kubeconfig/kube-proxy_config.tpl
+++ b/modules/kubeconfig/kube-proxy_config.tpl
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${certificate-authority-data}
+    server: https://${apiserver_public_ip}:6443
+  name: kubernetes-the-hard-way
+contexts:
+- context:
+    cluster: kubernetes-the-hard-way
+    user: kube-proxy
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: kube-proxy
+  user:
+    as-user-extra: {}
+    client-certificate-data: ${client-certificate-data}
+    client-key-data: ${client-key-data}

--- a/modules/kubeconfig/kubelet_config.tpl
+++ b/modules/kubeconfig/kubelet_config.tpl
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: ${certificate-authority-data}
+    server: https://${apiserver_public_ip}:6443
+  name: kubernetes-the-hard-way
+contexts:
+- context:
+    cluster: kubernetes-the-hard-way
+    user: system:node:${node_name}
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: system:node:${node_name}
+  user:
+    as-user-extra: {}
+    client-certificate-data: ${client-certificate-data}
+    client-key-data: ${client-key-data}

--- a/modules/kubeconfig/kubelet_configs.tf
+++ b/modules/kubeconfig/kubelet_configs.tf
@@ -2,7 +2,7 @@
 data "template_file" "kubelet_config_template" {
   template = "${file("${path.module}/kubelet_config.tpl")}"
 
-  count = "${length(var.kubelet_node_names)}"
+  count = "${var.kubelet_count}"
 
   vars {
     certificate-authority-data = "${base64encode(var.kube_ca_crt_pem)}"

--- a/modules/kubeconfig/kubelet_configs.tf
+++ b/modules/kubeconfig/kubelet_configs.tf
@@ -1,21 +1,24 @@
-resource "null_resource" "kubelet_configs" {
+
+data "template_file" "kubelet_config_template" {
+  template = "${file("${path.module}/kubelet_config.tpl")}"
+
+  vars {
+    certificate-authority-data = "${base64encode(var.kube_ca_crt_pem)}"
+    client-certificate-data = "${base64encode(element(var.kubelet_crt_pems, count.index))}"
+    client-key-data = "${base64encode(element(var.kubelet_key_pems, count.index))}"
+    apiserver_public_ip = "${var.apiserver_public_ip}"
+  }
+}
+
+resource "local_file" "kubelet_config" {
+
   count = "${length(var.kubelet_node_names)}"
+  content  = "${data.template_file.kube-proxy_config_template.rendered}"
+  filename = "./generated/${element(var.kubelet_node_names, count.index)}.kubeconfig"
+}
 
-  provisioner "local-exec" {
-    command = "kubectl config set-cluster kubernetes-the-hard-way --certificate-authority=${var.ca_crt_file} --embed-certs=true --server=https://${var.apiserver_public_ip}:6443 --kubeconfig=./generated/${element(var.kubelet_node_names, count.index)}.kubeconfig"
-  }
-
-  provisioner "local-exec" {
-    command = "kubectl config set-credentials system:node:${element(var.kubelet_node_names, count.index)} --client-certificate=${element(var.kubelet_crt_files, count.index)} --client-key=${element(var.kubelet_key_files, count.index)} --embed-certs=true --kubeconfig=./generated/${element(var.kubelet_node_names, count.index)}.kubeconfig"
-  }
-
-  provisioner "local-exec" {
-    command = "kubectl config set-context default --cluster=kubernetes-the-hard-way --user=system:node:${element(var.kubelet_node_names, count.index)} --kubeconfig=./generated/${element(var.kubelet_node_names, count.index)}.kubeconfig"
-  }
-
-  provisioner "local-exec" {
-    command = "kubectl config use-context default --kubeconfig=./generated/${element(var.kubelet_node_names, count.index)}.kubeconfig"
-  }
+resource "null_resource" "kubelet-provisioner" {
+  count = "${length(var.kubelet_node_names)}"
 
   connection {
     type         = "ssh"

--- a/modules/kubeconfig/kubelet_configs.tf
+++ b/modules/kubeconfig/kubelet_configs.tf
@@ -2,18 +2,21 @@
 data "template_file" "kubelet_config_template" {
   template = "${file("${path.module}/kubelet_config.tpl")}"
 
+  count = "${length(var.kubelet_node_names)}"
+
   vars {
     certificate-authority-data = "${base64encode(var.kube_ca_crt_pem)}"
     client-certificate-data = "${base64encode(element(var.kubelet_crt_pems, count.index))}"
     client-key-data = "${base64encode(element(var.kubelet_key_pems, count.index))}"
     apiserver_public_ip = "${var.apiserver_public_ip}"
+    node_name = "${element(var.kubelet_node_names, count.index)}"
   }
 }
 
 resource "local_file" "kubelet_config" {
 
   count = "${length(var.kubelet_node_names)}"
-  content  = "${data.template_file.kube-proxy_config_template.rendered}"
+  content  = "${data.template_file.kubelet_config_template.*.rendered[count.index]}"
   filename = "./generated/${element(var.kubelet_node_names, count.index)}.kubeconfig"
 }
 

--- a/modules/kubeconfig/vars.tf
+++ b/modules/kubeconfig/vars.tf
@@ -12,24 +12,24 @@ variable "node_user" {
   description = "The node user name to use for provision the certificates to the nodes"
 }
 
-variable "kubelet_crt_files" {
-  type        = "list"
-  description = "The list of kubelet certificate files"
-}
-
-variable "kubelet_key_files" {
-  type        = "list"
-  description = "The list of kubelet key files"
-}
-
-variable "kube-proxy_crt_file" {
-  description = "The kube-proxy certificate file"
-}
-
-variable "kube-proxy_key_file" {
-  description = "The kube-proxy key file"
-}
-
-variable "ca_crt_file" {
+variable "kube_ca_crt_pem" {
   description = "The CA certificate file"
+}
+
+variable "kube-proxy_crt_pem" {
+  description = "The kube-proxy certificate data"
+}
+
+variable "kube-proxy_key_pem" {
+  description = "The kube-proxy key data"
+}
+
+variable "kubelet_crt_pems" {
+  type        = "list"
+  description = "The list of kubelet certificate pems"
+}
+
+variable "kubelet_key_pems" {
+  type        = "list"
+  description = "The list of kubelet key pems"
 }

--- a/modules/kubeconfig/vars.tf
+++ b/modules/kubeconfig/vars.tf
@@ -3,6 +3,10 @@ variable "kubelet_node_names" {
   description = "The list of nodes that will have a kubelet client certificate generated"
 }
 
+variable "kubelet_count" {
+  description = "Count of kubelets (required for the kubelet config template data source). Must be identical to the count of workers"
+}
+
 variable "apiserver_public_ip" {
   type        = "string"
   description = "The public IP address for the apiserver certificate"

--- a/modules/pki/admin_cert.tf
+++ b/modules/pki/admin_cert.tf
@@ -36,10 +36,10 @@ resource "tls_locally_signed_cert" "kube_admin" {
 
 resource "local_file" "kube_admin_key" {
   content  = "${tls_private_key.kube_admin.private_key_pem}"
-  filename = "./tls/admin-key.pem"
+  filename = "./generated/tls/admin-key.pem"
 }
 
 resource "local_file" "kube_admin_crt" {
   content  = "${tls_locally_signed_cert.kube_admin.cert_pem}"
-  filename = "./tls/admin.pem"
+  filename = "./generated/tls/admin.pem"
 }

--- a/modules/pki/apiserver_cert.tf
+++ b/modules/pki/apiserver_cert.tf
@@ -67,7 +67,7 @@ resource "null_resource" "apiserver_certs" {
   }
 
   provisioner "file" {
-    source      = "tls/apiserver-key.pem"
+    source      = "./generated/tls/apiserver-key.pem"
     destination = "~/apiserver-key.pem"
   }
 }

--- a/modules/pki/apiserver_cert.tf
+++ b/modules/pki/apiserver_cert.tf
@@ -43,12 +43,12 @@ resource "tls_locally_signed_cert" "apiserver" {
 
 resource "local_file" "apiserver_key" {
   content  = "${tls_private_key.apiserver.private_key_pem}"
-  filename = "./tls/apiserver-key.pem"
+  filename = "./generated/tls/apiserver-key.pem"
 }
 
 resource "local_file" "apiserver_crt" {
   content  = "${tls_locally_signed_cert.apiserver.cert_pem}"
-  filename = "./tls/apiserver.pem"
+  filename = "./generated/tls/apiserver.pem"
 }
 
 resource "null_resource" "apiserver_certs" {
@@ -62,7 +62,7 @@ resource "null_resource" "apiserver_certs" {
   }
 
   provisioner "file" {
-    source      = "./tls/apiserver.pem"
+    source      = "./generated/tls/apiserver.pem"
     destination = "~/apiserver.pem"
   }
 

--- a/modules/pki/ca.tf
+++ b/modules/pki/ca.tf
@@ -32,12 +32,12 @@ resource "tls_self_signed_cert" "kube_ca" {
 
 resource "local_file" "kube_ca_key" {
   content  = "${tls_private_key.kube_ca.private_key_pem}"
-  filename = "./tls/ca-key.pem"
+  filename = "./generated/tls/ca-key.pem"
 }
 
 resource "local_file" "kube_ca_crt" {
   content  = "${tls_self_signed_cert.kube_ca.cert_pem}"
-  filename = "./tls/ca.pem"
+  filename = "./generated/tls/ca.pem"
 }
 
 resource "null_resource" "ca_certs" {
@@ -51,12 +51,12 @@ resource "null_resource" "ca_certs" {
   }
 
   provisioner "file" {
-    source      = "./tls/ca.pem"
+    source      = "./generated/tls/ca.pem"
     destination = "~/ca.pem"
   }
 
   provisioner "file" {
-    source      = "./tls/ca-key.pem"
+    source      = "./generated/tls/ca-key.pem"
     destination = "~/ca-key.pem"
   }
 }

--- a/modules/pki/kube-proxy_cert.tf
+++ b/modules/pki/kube-proxy_cert.tf
@@ -36,10 +36,10 @@ resource "tls_locally_signed_cert" "kube_proxy" {
 
 resource "local_file" "kube_proxy_key" {
   content  = "${tls_private_key.kube_proxy.private_key_pem}"
-  filename = "./tls/kube-proxy-key.pem"
+  filename = "./generated/tls/kube-proxy-key.pem"
 }
 
 resource "local_file" "kube_proxy_crt" {
   content  = "${tls_locally_signed_cert.kube_proxy.cert_pem}"
-  filename = "./tls/kube-proxy.pem"
+  filename = "./generated/tls/kube-proxy.pem"
 }

--- a/modules/pki/kubelet_certs.tf
+++ b/modules/pki/kubelet_certs.tf
@@ -52,14 +52,14 @@ resource "local_file" "kubelet_key" {
   count = "${length(var.kubelet_node_names)}"
 
   content  = "${tls_private_key.kubelet.*.private_key_pem[count.index]}"
-  filename = "./tls/kubelet/${element(var.kubelet_node_names, count.index)}-key.pem"
+  filename = "./generated/tls/kubelet/${element(var.kubelet_node_names, count.index)}-key.pem"
 }
 
 resource "local_file" "kubelet_crt" {
   count = "${length(var.kubelet_node_names)}"
 
   content  = "${tls_locally_signed_cert.kubelet.*.cert_pem[count.index]}"
-  filename = "./tls/kubelet/${element(var.kubelet_node_names, count.index)}.pem"
+  filename = "./generated/tls/kubelet/${element(var.kubelet_node_names, count.index)}.pem"
 }
 
 resource "null_resource" "kubelet_certs" {
@@ -98,7 +98,7 @@ resource "null_resource" "worker_ca_cert" {
   }
 
   provisioner "file" {
-    source      = "./tls/ca-key.pem"
+    source      = "./generated/tls/ca-key.pem"
     destination = "~/ca-key.pem"
   }
   

--- a/modules/pki/kubelet_certs.tf
+++ b/modules/pki/kubelet_certs.tf
@@ -75,12 +75,12 @@ resource "null_resource" "kubelet_certs" {
   }
 
   provisioner "file" {
-    source      = "tls/kubelet/${element(var.kubelet_node_names, count.index)}.pem"
+    source      = "./generated/tls/kubelet/${element(var.kubelet_node_names, count.index)}.pem"
     destination = "~/${element(var.kubelet_node_names, count.index)}.pem"
   }
 
   provisioner "file" {
-    source      = "tls/kubelet/${element(var.kubelet_node_names, count.index)}-key.pem"
+    source      = "./generated/tls/kubelet/${element(var.kubelet_node_names, count.index)}-key.pem"
     destination = "~/${element(var.kubelet_node_names, count.index)}-key.pem"
   }
 }
@@ -98,8 +98,8 @@ resource "null_resource" "worker_ca_cert" {
   }
 
   provisioner "file" {
-    source      = "./generated/tls/ca-key.pem"
-    destination = "~/ca-key.pem"
+    source      = "./generated/tls/ca.pem"
+    destination = "~/ca.pem"
   }
   
 }

--- a/modules/pki/outputs.tf
+++ b/modules/pki/outputs.tf
@@ -6,6 +6,15 @@ output "kubelet_key_files" {
   value = "${local_file.kubelet_key.*.filename}"
 }
 
+output "kubelet_crt_pems" {
+  value = "${tls_locally_signed_cert.kubelet.*.cert_pem}"
+}
+
+output "kubelet_key_pems" {
+  value = "${tls_private_key.kubelet.*.private_key_pem}"
+}
+
+
 output "kube-proxy_crt_file" {
   value = "${local_file.kube_proxy_crt.filename}"
 }
@@ -14,6 +23,18 @@ output "kube-proxy_key_file" {
   value = "${local_file.kube_proxy_key.filename}"
 }
 
+output "kube-proxy_crt_pem" {
+  value = "${tls_locally_signed_cert.kube_proxy.cert_pem}"
+}
+
+output "kube-proxy_key_pem" {
+  value = "${tls_private_key.kube_proxy.private_key_pem}"
+}
+
 output "kube_ca_crt_file" {
   value = "${local_file.kube_ca_crt.filename}"
+}
+
+output "kube_ca_crt_pem" {
+  value = "${tls_self_signed_cert.kube_ca.cert_pem}"
 }


### PR DESCRIPTION
Generate kubeconfigs from template instead of kubectl cmds, as Terraform runs the commands simultaneously, which causes them to fail sometimes because of an existing lock from another running kubectl.